### PR TITLE
Create Animations component - store all react-spring properties here

### DIFF
--- a/src/components/Animations.js
+++ b/src/components/Animations.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { useSpring } from "react-spring";
+
+// The "fade-in" effect properties are stored here
+const SpringProps = () => {
+
+    // Animation speed is the "tension" value
+    const springProps = useSpring({opacity: 1, from: {opacity: 0}, config: { mass: 5, tension: 250, friction: 80 }});
+
+    return springProps;
+}
+
+export default SpringProps;
+
+
+

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from "react";
 import { connect } from 'react-redux';
 // ACTIONS
 import { updateList, deleteList } from '../actions/index';
-import {useSpring, animated} from "react-spring";
-
+import { animated } from "react-spring";
+import SpringProps from "./Animations";
 import axios from "axios";
 import jwt_decode from "jwt-decode";
 import { useForm } from "react-hook-form";
@@ -20,8 +20,6 @@ const Dashboard = (props) => {
     const userName = decoded.first_name;
 
     const [loadStatus, setLoadStatus] = useState(false);
-
-    const springProps = useSpring({opacity: 1, from: {opacity: 0}, config: { mass: 5, tension: 250, friction: 80 }});
 
     //UPDATE FUNCTION
     const handleChanges = e => {
@@ -60,7 +58,7 @@ const Dashboard = (props) => {
 
     return (
     <div className = "dashboard">
-        <animated.div style = {springProps}>
+        <animated.div style = {SpringProps()}>
         <div className = "status">
         <GetStatus loaded = {loadStatus} username = {userName} />
         </div>
@@ -74,7 +72,7 @@ const Dashboard = (props) => {
                 <input type = "submit" />
             </form>
         </div>
-        <animated.div style = {springProps}>
+        <animated.div style = {SpringProps()}>
         <div className = "allcards">
 
         {data.map(data => {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { Link, Route, Switch } from "react-router-dom";
-import {useSpring, animated} from "react-spring";
+import { animated } from "react-spring";
+import SpringProps from "./Animations";
 
 
 export default function Home() {
-    const props = useSpring({opacity: 1, from: {opacity: 0}, config: { mass: 5, tension: 250, friction: 80 }});
     return (
-        <animated.div style = {props}>
+        <animated.div style = {SpringProps()}>
         <div className = "maincard">
         <div className = "homepage">
             <div className = "hometext">

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -5,22 +5,21 @@ import { TextField } from "formik-material-ui";
 import { withFormik, Form, Field } from "formik";
 import * as Yup from "yup";
 import { Link, Route, Switch } from "react-router-dom";
-import {useSpring, animated} from "react-spring";
+import { animated } from "react-spring";
+import SpringProps from "./Animations";
 
 
 
 const Login = ({values, handleChange, touched, errors, status}) => {
     const [users, setUsers] = useState([]);
 
-    const props = useSpring({opacity: 1, from: {opacity: 0}, config: { mass: 5, tension: 250, friction: 80 }});
-    
     useEffect(() => {
         console.log("Status has changed", status);
         status && setUsers(users => [...users, status]);
     }, [status]);
     
     return (
-        <animated.div style = {props}>
+        <animated.div style = {SpringProps()}>
         <div className = "maincard">
         <div className = "login">
             <div className = "usercard">

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -5,13 +5,12 @@ import { TextField } from "formik-material-ui";
 import { withFormik, Form, Field } from "formik";
 import * as Yup from "yup";
 import { Link, Route, Switch } from "react-router-dom";
-import {useSpring, animated} from "react-spring";
+import { animated } from "react-spring";
+import SpringProps from "./Animations";
 
 
 const Register = ({values, handleChange, touched, errors, status}) => {
     const [users, setUsers] = useState([]);
-
-    const props = useSpring({opacity: 1, from: {opacity: 0}, config: { mass: 5, tension: 250, friction: 80 }});
 
     useEffect(() => {
         console.log("Status has changed", status);
@@ -19,7 +18,7 @@ const Register = ({values, handleChange, touched, errors, status}) => {
     }, [status]);
 
     return (
-        <animated.div style = {props}>
+        <animated.div style = {SpringProps()}>
         <div className = "maincard">
         <div className = "register">
             <div className = "usercard">

--- a/src/utils/axiosWithAuth.js
+++ b/src/utils/axiosWithAuth.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 
-
 export const axiosWithAuth = () => {
   // get the token from localstorage
   const token = window.localStorage.getItem('token');


### PR DESCRIPTION
Previously, the props for react-spring had to be defined in every component where the animation is used. This was inefficient. With these changes, we are storing all the properties in Animations.js and simply importing them as necessary.